### PR TITLE
Remove reference to default parameter for out

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Minfifies the output. Default is `false`.
 Any additional options you'd like to be passed in to browserify. Again, documented [here](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts). Default is `{ extensions: ['.js', '.json', '.coffee'] }`.
 
 ##### out
-Where you want to output your built js file to in your `public` folder (or whatever you have set `output` to in the roots settings). Default is `js/build.js`
+Where you want to output your built js file to in your `public` folder (or whatever you have set `output` to in the roots settings). There is no default. Recommended is `js/build.js`
 
 ##### transforms
 If you'd like to add additional custom transforms, you can do it through this option. Pass either a transform function or an array of functions and they will be included in the pipeline. Default is `coffeeify` (add that string to your array if you want to keep coffeeify as well, otherwise it will be overridden).


### PR DESCRIPTION
As out doesn't actually have a default value any more, relying on it being so throws an error.