### PR TITLE
Update to uglifyify with fixed 'sourceMap' name

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mold-source-map": "0.4.x",
     "roots-util": "0.1.x",
     "through2": "2.x",
-    "uglifyify": "3.x",
+    "uglifyify": "4.x",
     "when": "3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
`sourcemap` (before uglifyify@4.0.1) is causing source maps to be generated every time `minify` option is set to `true`.
See the [issue](https://github.com/hughsk/uglifyify/pull/67) backing latest commit.

It causes `roots compile` to fail because source map is generated next to script content and uglify refuses to minify with message:

```
TypeError: path must be a string or Buffer while parsing file: ...\website\assets\js\main.coffee
    at Object.fs.openSync (fs.js:1:1)
    at Object.fs.readFileSync (fs.js:1:1)
    at Object.exports.minify (...\website\node_modules\uglify-js\tools\node.js:1:1)
    at Stream.ready (...\website\node_modules\roots-browserify\node_modules\uglifyify\index.js:1:1)
    at Stream.<anonymous> (...\website\node_modules\roots-browserify\node_modules\uglifyify\index.js:1:1)
```